### PR TITLE
Updated nomination limit for taiko BNs

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
@@ -23,7 +23,10 @@ Sustained behaviour in conflict with these expectations is grounds for dismissal
   - **Falling below the 90 day requirements with more than 60 days worth of nominations will result in an activity warning.** 
   - When warned for activity, minimum activity requirements for your respective game mode(s) must be met over the course of one month. 
   - Failing to meet the required minimum when being warned for it prior may result in removal from the Beatmap Nominators.
-- **You cannot exceed 75 unique nominations over any 90 day period.** Those exceeding this amount will first be warned and then removed if they do not manage their activity accordingly.
+- Beatmap Nominators are expected to stay below a maximum number of nominations, with each mode having its own nomination cap over a 90 day period. Exceeding this amount will lead to a warning, followed by a removal if they fail to manage their activity accordingly.
+
+  - osu!, osu!catch, osu!mania: 75 unique nominations.
+  - osu!taiko: 100 unique nominations.
 
 ### Requirements
 


### PR DESCRIPTION
The past few days the nomination cap has been discussed and we came to the conclusion to update taiko only from 75 to 100 unique nominations because of the simplicity and activity of some nominators in relation to other game modes.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [ ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
